### PR TITLE
Fix class constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
     - extra-android-support
     - extra-android-m2repository

--- a/labelledspinner/build.gradle
+++ b/labelledspinner/build.gradle
@@ -19,13 +19,13 @@ apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 23
         versionCode 114
-        versionName "1.1.4"
+        versionName "1.1.5"
     }
     buildTypes {
         release {
@@ -48,7 +48,7 @@ publish {
     userOrg = 'farbodsalamat-zadeh'
     groupId = 'com.farbod.labelledspinner' // to avoid confusion, same name as project dir'
     artifactId = 'labelledspinner' // same name as library module
-    publishVersion = '1.1.4'
+    publishVersion = '1.1.5'
     desc = 'A Spinner component with a floating label for Android' +
             ' (similar to EditText components wrapped in a TextInputLayout).'
     website = 'https://github.com/FarbodSalamat-Zadeh/LabelledSpinner'

--- a/labelledspinner/build.gradle
+++ b/labelledspinner/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 23
-        versionCode 114
+        versionCode 115
         versionName "1.1.5"
     }
     buildTypes {

--- a/labelledspinner/src/main/java/com/farbod/labelledspinner/LabelledSpinner.java
+++ b/labelledspinner/src/main/java/com/farbod/labelledspinner/LabelledSpinner.java
@@ -106,15 +106,16 @@ public class LabelledSpinner extends LinearLayout implements AdapterView.OnItemS
      */
     private boolean mDefaultErrorEnabled;
 
-
     public LabelledSpinner(Context context) {
         this(context, null);
     }
 
     public LabelledSpinner(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+        super(context, attrs, 0);
+        setUpLayout(context, attrs);
     }
 
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public LabelledSpinner(Context context, AttributeSet attrs, int defStyleAttr) {
         this(context, attrs, defStyleAttr, 0);
     }
@@ -122,7 +123,10 @@ public class LabelledSpinner extends LinearLayout implements AdapterView.OnItemS
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public LabelledSpinner(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+        setUpLayout(context, attrs);
+    }
 
+    private void setUpLayout(Context context, AttributeSet attrs) {
         prepareLayout(context);
 
         mLabel = (TextView) getChildAt(0);
@@ -163,7 +167,6 @@ public class LabelledSpinner extends LinearLayout implements AdapterView.OnItemS
 
         a.recycle();
     }
-
 
     /**
      * Inflates the layout and sets layout parameters

--- a/labelledspinner/src/main/java/com/farbod/labelledspinner/LabelledSpinner.java
+++ b/labelledspinner/src/main/java/com/farbod/labelledspinner/LabelledSpinner.java
@@ -111,13 +111,12 @@ public class LabelledSpinner extends LinearLayout implements AdapterView.OnItemS
     }
 
     public LabelledSpinner(Context context, AttributeSet attrs) {
-        super(context, attrs, 0);
-        setUpLayout(context, attrs);
+        this(context, attrs, 0);
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public LabelledSpinner(Context context, AttributeSet attrs, int defStyleAttr) {
-        this(context, attrs, defStyleAttr, 0);
+        super(context, attrs, defStyleAttr);
+        setUpLayout(context, attrs);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,6 +39,6 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-//    compile 'com.farbod.labelledspinner:labelledspinner:1.1.4'
-    compile project(':labelledspinner')  // Used when testing latest features of library module
+    compile 'com.farbod.labelledspinner:labelledspinner:1.1.4'
+//    compile project(':labelledspinner')  // Used when testing latest features of library module
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.farbod.labelledspinner.sample"
@@ -39,6 +39,6 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.farbod.labelledspinner:labelledspinner:1.1.4'
-    //compile project(':labelledspinner')  // Used when testing latest features of library module
+//    compile 'com.farbod.labelledspinner:labelledspinner:1.1.4'
+    compile project(':labelledspinner')  // Used when testing latest features of library module
 }


### PR DESCRIPTION
They were calling a base constructor targeting Lollipop, causing a crash if using the component in lower Android versions.
